### PR TITLE
Use LLVM11 uniformely

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,9 @@
 {% set name = "pocl" %}
 {% set version = "1.6" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set sha256 = "b0a4c0c056371b6f0db726b88fbb76bbee94948fb2abd4dbc8d958f7c42f766c" %}
 
-{% if target_platform is defined and target_platform.startswith("osx-") %}
 {% set llvm_version = "11.0.0" %}
-{% else %}
-{% set llvm_version = "10.0.1" %}
-{% endif %}
 
 package:
   name: {{ name|lower }}
@@ -18,6 +14,7 @@ source:
     sha256: {{ sha256 }}
     patches:
       - gh887.diff
+      - patches/gh904.patch
 
 build:
   number: {{ build_number }}

--- a/recipe/patches/gh904.patch
+++ b/recipe/patches/gh904.patch
@@ -1,0 +1,39 @@
+From 797f16fa0cb0caac638500213307e425620bb1f1 Mon Sep 17 00:00:00 2001
+From: Mauri Mustonen <mauri.mustonen@tuni.fi>
+Date: Fri, 8 Jan 2021 12:49:23 +0200
+Subject: [PATCH] disable jump threading pass from duplicating blocks and
+ messing up parellel region construction
+
+---
+ lib/CL/pocl_llvm_utils.cc | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/lib/CL/pocl_llvm_utils.cc b/lib/CL/pocl_llvm_utils.cc
+index aa0d33dd..b48cc78d 100644
+--- a/lib/CL/pocl_llvm_utils.cc
++++ b/lib/CL/pocl_llvm_utils.cc
+@@ -323,6 +323,21 @@ void InitializeLLVM() {
+     O->addOccurrence(1, StringRef("vectorizer-min-trip-count"), StringRef("2"),
+                      false);
+ 
++    // Disable jump threading optimization with following two options from
++    // duplicating blocks. Using jump threading will mess up parallel region
++    // construction especially when kernel contains barriers.
++    // TODO: If enabled then parallel region construction code needs
++    // improvements and make sure it doesn't disallow other optimizations like
++    // vectorization.
++    O = opts["jump-threading-threshold"];
++    assert(O && "could not find LLVM option 'jump-threading-threshold'");
++    O->addOccurrence(1, StringRef("jump-threading-threshold"), StringRef("0"),
++                     false);
++    O = opts["jump-threading-implication-search-threshold"];
++    assert(O && "could not find LLVM option 'jump-threading-implication-search-threshold'");
++    O->addOccurrence(1, StringRef("jump-threading-implication-search-threshold"), StringRef("0"),
++                     false);
++
+     if (pocl_get_bool_option("POCL_VECTORIZER_REMARKS", 0) == 1) {
+       // Enable diagnostics from the loop vectorizer.
+       O = opts["pass-remarks-missed"];
+-- 
+2.25.1
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes #55

<!--
Please add any other relevant info below:
-->

As a side note `find_package(CUDA REQUIRED)` is deprected since CMake 3.10 and should be replaced by `find_package(CUDAToolkit REQUIRED)` 