### PR TITLE
Use CUDA 10 for ppc64le

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,18 +12,22 @@ jobs:
         CONFIG: linux_64_libhwloc2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+        SHORT_CONFIG: linux_64_libhwloc2
       linux_64_libhwloc2.9.3:
         CONFIG: linux_64_libhwloc2.9.3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.2
+        SHORT_CONFIG: linux_64_libhwloc2.9.3
       linux_ppc64le_libhwloc2:
         CONFIG: linux_ppc64le_libhwloc2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
+        SHORT_CONFIG: linux_ppc64le_libhwloc2
       linux_ppc64le_libhwloc2.9.3:
         CONFIG: linux_ppc64le_libhwloc2.9.3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
+        SHORT_CONFIG: linux_ppc64le_libhwloc2.9.3
   timeoutInMinutes: 360
 
   steps:
@@ -53,3 +57,32 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
+        fi
+        ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -19,11 +19,11 @@ jobs:
       linux_ppc64le_libhwloc2:
         CONFIG: linux_ppc64le_libhwloc2
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
       linux_ppc64le_libhwloc2.9.3:
         CONFIG: linux_ppc64le_libhwloc2.9.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,12 +11,15 @@ jobs:
       osx_64_libhwloc2:
         CONFIG: osx_64_libhwloc2
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_libhwloc2
       osx_64_libhwloc2.9.3:
         CONFIG: osx_64_libhwloc2.9.3
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_libhwloc2.9.3
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
 
   steps:
@@ -40,3 +43,32 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+      # Archive everything in CONDA_BLD_DIR except environments
+      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Archive the CONDA_BLD_DIR environments only when the job fails
+        export ENV_ARTIFACT_PREFIX=conda_envs
+      fi
+      ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.ci_support/linux_ppc64le_libhwloc2.9.3.yaml
+++ b/.ci_support/linux_ppc64le_libhwloc2.9.3.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+- quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
 enable_cuda:
 - 'True'
 libhwloc:

--- a/.ci_support/linux_ppc64le_libhwloc2.yaml
+++ b/.ci_support/linux_ppc64le_libhwloc2.yaml
@@ -11,7 +11,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2
+- quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2
 enable_cuda:
 - 'True'
 libhwloc:

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,3 +10,5 @@ provider:
   linux_aarch64: native
   linux_ppc64le: azure
 test: native
+azure:
+  store_build_artifacts: true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,7 +4,7 @@ libhwloc:
 
 docker_image:                                           # [linux64 or ppc64le or aarch64]
   - quay.io/condaforge/linux-anvil-cuda:11.2            # [linux64]
-  - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.2    # [ppc64le]
+  - quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2    # [ppc64le]
   - quay.io/condaforge/linux-anvil-aarch64-cuda:11.2    # [aarch64]
 
 cuda_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "5.0" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set sha256 = "fd0bb6e50c2286278c11627b71177991519e1f7ab2576bd8d8742974db414549" %}
 
 {% set llvm_version = "15.0.7" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,7 +117,8 @@ outputs:
       run:
         - {{ pin_subpackage("pocl-core", exact=True) }}
       run_constrained:
-        - __cuda >=11
+        - __cuda >=11  # [not ppc64le]
+        - __cuda >=10.2  # [ppc64le]
     test:
       commands:
         - test -f $PREFIX/lib/pocl/libpocl-devices-cuda.so      # [unix]


### PR DESCRIPTION
This fixes the segfaults we have seen on Lassen with the `pocl-5.0_{0,1}` package on Nvidia:

```
$ gdb --args python mirgecom/examples/wave.py --no-mpi
[...]
Using SVM-based memory pool on <pyopencl.Device 'Tesla V100-SXM2-16GB' on 'Portable Computing Language' at 0x10148bf90>.
/usr/WS1/diener3/Work/edebug/arraycontext/arraycontext/impl/pyopencl/__init__.py:139: UserWarning: You are using the PyOpenCLArrayContext on a GPU, but you are running Python in debug mode. Use 'python -O' for a noticeable speed improvement.
  warn("You are using the PyOpenCLArrayContext on a GPU, but you "
512 elements
[Detaching after vfork from child process 166274]
[New Thread 0x200ade60f1b0 (LWP 166275)]

Program received signal SIGSEGV, Segmentation fault.
0x0000200826470f38 in pocl_cuda_finalize_command ()
(gdb) bt
#0  0x0000200826470f38 in pocl_cuda_finalize_command ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/pocl/libpocl-devices-cuda.so
#1  0x0000200816affc28 in POclWaitForEvents ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/libpocl.so.2.12.0
#2  0x0000200815da02a8 in clWaitForEvents_hid ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/python3.11/site-packages/pyopencl/../../../libOpenCL.so.1
#3  0x0000200815c6223c in pyopencl::wait_for_events(pybind11::object) ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/python3.11/site-packages/pyopencl/_cl.cpython-311-powerpc64le-linux-gnu.so
#4  0x0000200815c27134 in void pybind11::cpp_function::initialize<void (*&)(pybind11::object), void, pybind11::object, pybind11::name, pybind11::scope, pybind11::sibling>(void (*&)(pybind11::object), void (*)(pybind11::object), pybind11::name const&, pybind11::scope const&, pybind11::sibling const&)::{lambda(pybind11::detail::function_call&)#3}::_FUN(pybind11::detail::function_call&) ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/python3.11/site-packages/pyopencl/_cl.cpython-311-powerpc64le-linux-gnu.so
#5  0x0000200815c075a8 in pybind11::cpp_function::dispatcher(_object*, _object*, _object*) ()
   from /usr/WS1/diener3/Work/edebug/miniforge3/envs/ceesd/lib/python3.11/site-packages/pyopencl/_cl.cpython-311-powerpc64le-linux-gnu.so
```

Lassen uses cuda-10.1.243 by default, but switching to cuda-11.x did not resolve this.

Built ppc64le package:

[pocl-feedstock_conda_artifacts_20240207.2.1_linux_ppc64le_libhwloc2.9.3.zip](https://github.com/conda-forge/pocl-feedstock/files/14214122/pocl-feedstock_conda_artifacts_20240207.2.1_linux_ppc64le_libhwloc2.9.3.zip)

To installed the fixed package:

```
$ wget https://github.com/conda-forge/pocl-feedstock/files/14214122/pocl-feedstock_conda_artifacts_20240207.2.1_linux_ppc64le_libhwloc2.9.3.zip

$ unzip pocl-feedstock_conda_artifacts_20240207.2.1_linux_ppc64le_libhwloc2.9.3.zip

$ conda install build_artifacts/linux-ppc64le/pocl-cuda-5.0-h5860f63_1.conda
```
---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
